### PR TITLE
added specsInfo function, updated ProductCard component, small fixes to styles and theme

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -1,3 +1,5 @@
+@import './modules//shared//variables.scss';
+
 @font-face {
   font-family: Mont;
   src: url(./fonts/Mont-Regular.otf);
@@ -21,5 +23,5 @@
 }
 body {
   margin: 0;
-  background-color: #E2E6E9;
+  background-color: $color-background-hover;
 }

--- a/src/modules/shared/ProductCard/ProductCard.tsx
+++ b/src/modules/shared/ProductCard/ProductCard.tsx
@@ -18,17 +18,18 @@ import {
   imageBoxStyle,
   nameTypographyStyle,
   priceBoxStyle,
-  specLabelTypographyStyle,
-  specRowBoxStyle,
+  priceTypographyStyle,
   specsBoxStyle,
 } from './ProductCardStyle';
+import { SpecsInfo } from '../components/SpecsInfo/SpecsInfo';
+import { getCardSpecs } from '../../../utils/functions/getProductSpecs';
 
 type Props = {
   product: ProductCardInfo;
 };
 
 export const ProductCard: React.FC<Props> = ({ product }) => {
-  const { name, price, fullPrice, screen, capacity, ram, image } = product;
+  const { name, price, fullPrice, image } = product;
 
   return (
     <Card sx={cardStyle}>
@@ -42,16 +43,12 @@ export const ProductCard: React.FC<Props> = ({ product }) => {
       </Box>
 
       <CardContent sx={cardContentStyle}>
-        <Typography
-          variant="body1"
-          color="primary.main"
-          sx={nameTypographyStyle}
-        >
+        <Typography variant="body1" sx={nameTypographyStyle}>
           {name}
         </Typography>
 
         <Box sx={priceBoxStyle}>
-          <Typography variant="h3" color="primary.main">
+          <Typography variant="h3" sx={priceTypographyStyle}>
             ${price}
           </Typography>
           {price !== fullPrice && (
@@ -64,9 +61,7 @@ export const ProductCard: React.FC<Props> = ({ product }) => {
         <Divider sx={dividerStyle} />
 
         <Box sx={specsBoxStyle}>
-          <SpecRow label="Screen" value={screen} />
-          <SpecRow label="Capacity" value={capacity} />
-          <SpecRow label="RAM" value={ram} />
+          <SpecsInfo specs={getCardSpecs(product)} textVariant={'body2'} />
         </Box>
 
         <Box sx={buttonBoxStyle}>
@@ -79,12 +74,3 @@ export const ProductCard: React.FC<Props> = ({ product }) => {
     </Card>
   );
 };
-
-const SpecRow = ({ label, value }: { label: string; value: string }) => (
-  <Box sx={specRowBoxStyle}>
-    <Typography variant="body2" sx={specLabelTypographyStyle}>
-      {label}
-    </Typography>
-    <Typography variant="body2">{value}</Typography>
-  </Box>
-);

--- a/src/modules/shared/ProductCard/ProductCardStyle.ts
+++ b/src/modules/shared/ProductCard/ProductCardStyle.ts
@@ -37,11 +37,16 @@ export const cardContentStyle: SxProps<Theme> = {
 
 export const nameTypographyStyle: SxProps<Theme> = {
   paddingTop: '16px',
+  color: 'primary.main',
 };
 
 export const priceBoxStyle: SxProps<Theme> = {
   display: 'flex',
   gap: '8px',
+};
+
+export const priceTypographyStyle: SxProps<Theme> = {
+  color: 'primary.main',
 };
 
 export const fullPriceTypographyStyle: SxProps<Theme> = {
@@ -54,9 +59,6 @@ export const dividerStyle: SxProps<Theme> = {
 };
 
 export const specsBoxStyle: SxProps<Theme> = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '8px',
   paddingTop: '8px',
   paddingBottom: '8px',
 };
@@ -66,13 +68,4 @@ export const buttonBoxStyle: SxProps<Theme> = {
   flexDirection: 'row',
   gap: '8px',
   height: '40px',
-};
-
-export const specRowBoxStyle: SxProps<Theme> = {
-  display: 'flex',
-  justifyContent: 'space-between',
-};
-
-export const specLabelTypographyStyle: SxProps<Theme> = {
-  color: 'secondary.dark',
 };

--- a/src/modules/shared/components/SpecsInfo/SpecsInfo.tsx
+++ b/src/modules/shared/components/SpecsInfo/SpecsInfo.tsx
@@ -1,0 +1,26 @@
+import { Box, Typography } from '@mui/material';
+import React from 'react';
+
+import { specsInfoStyle } from './SpecsInfoStyles';
+
+type Props = {
+  specs: Record<string, string>;
+  textVariant: 'body1' | 'body2';
+};
+
+export const SpecsInfo: React.FC<Props> = ({ specs, textVariant }) => {
+  return (
+    <Box sx={specsInfoStyle.specsBox}>
+      {Object.entries(specs).map(([label, value]) => (
+        <Box key={label} sx={specsInfoStyle.rowBox}>
+          <Typography variant={textVariant} sx={specsInfoStyle.rowLabel}>
+            {label}
+          </Typography>
+          <Typography variant={textVariant} sx={specsInfoStyle.rowValue}>
+            {value}
+          </Typography>
+        </Box>
+      ))}
+    </Box>
+  );
+};

--- a/src/modules/shared/components/SpecsInfo/SpecsInfoStyles.ts
+++ b/src/modules/shared/components/SpecsInfo/SpecsInfoStyles.ts
@@ -1,0 +1,19 @@
+import { SxProps, Theme } from '@mui/material';
+
+export const specsInfoStyle: Record<string, SxProps<Theme>> = {
+  specsBox: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+  },
+
+  rowBox: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    flexDirection: 'row',
+  },
+
+  rowLabel: { color: 'secondary.dark' },
+
+  rowValue: { color: 'primary.main' },
+};

--- a/src/modules/shared/variables.scss
+++ b/src/modules/shared/variables.scss
@@ -4,9 +4,11 @@ $color-secondary-accent: #476df4;
 $color-primary: #0f0f11;
 $color-secondary: #89939a;
 $color-icons: #b4bdc3;
+$color-elements: #e2e6e9;
+$color-background-hover: #fafbfc;
+$color-white: #ffffff;
 $color-success: #27ae60;
 $color-error: #eb5757;
-$color-elements: #E2E6E9;
 
 // Color selector colors
 $color-green: #27ae60;

--- a/src/themes/roundedOrange.ts
+++ b/src/themes/roundedOrange.ts
@@ -14,7 +14,7 @@ declare module '@mui/material/styles' {
   }
 }
 
-const theme = createTheme({
+export const theme = createTheme({
   breakpoints: {
     values: {
       desktop: 1200,
@@ -144,5 +144,3 @@ theme.typography.h4[theme.breakpoints.down('tablet')] = {
   lineHeight: '20px',
   letterSpacing: 0,
 };
-
-export default theme;

--- a/src/utils/Types.ts
+++ b/src/utils/Types.ts
@@ -1,6 +1,6 @@
 type Description = {
   title: string;
-  text: string;
+  text: string[];
 };
 
 export type SortBy = 'Newest' | 'Alphabetically' | 'Cheapest';
@@ -37,8 +37,8 @@ export type ProductDetailsInfo = {
   resolution: string;
   processor: string;
   ram: string;
-  camera: string;
-  zoom: string;
+  camera?: string;
+  zoom?: string;
   cell: string[];
 };
 export type CartItem = {

--- a/src/utils/functions/getProductSpecs.ts
+++ b/src/utils/functions/getProductSpecs.ts
@@ -1,0 +1,64 @@
+import { ProductCardInfo, ProductDetailsInfo } from '../Types';
+
+const specsDisplayNames = {
+  screen: 'Screen',
+  resolution: 'Resolution',
+  processor: 'Processor',
+  ram: 'RAM',
+  capacity: 'Built in memory',
+  camera: 'Camera',
+  zoom: 'Zoom',
+  cell: 'Cell',
+} as const;
+
+type SpecKey = keyof typeof specsDisplayNames;
+
+const specsForCard: SpecKey[] = ['screen', 'capacity', 'ram'];
+const specsForDetailsMain: SpecKey[] = [
+  'screen',
+  'resolution',
+  'processor',
+  'ram',
+];
+const specsForDetailsFull: SpecKey[] = [
+  'screen',
+  'resolution',
+  'processor',
+  'ram',
+  'capacity',
+  'camera',
+  'zoom',
+  'cell',
+];
+
+function buildSpecs<T extends Record<string, unknown>>(
+  product: T,
+  keys: SpecKey[],
+): Record<string, string> {
+  const specs: Record<string, string> = {};
+
+  keys.forEach(key => {
+    const value = product[key as keyof T];
+
+    if (value !== undefined && value !== null) {
+      const displayName = specsDisplayNames[key];
+      specs[displayName] = Array.isArray(value)
+        ? value.join(', ')
+        : String(value);
+    }
+  });
+
+  return specs;
+}
+
+export function getCardSpecs(product: ProductCardInfo) {
+  return buildSpecs(product, specsForCard);
+}
+
+export function getMainSpecs(product: ProductDetailsInfo) {
+  return buildSpecs(product, specsForDetailsMain);
+}
+
+export function getFullSpecs(product: ProductDetailsInfo) {
+  return buildSpecs(product, specsForDetailsFull);
+}


### PR DESCRIPTION
Implemented functions and component to display product specs:
`getCardSpecs(product)` - specs for card
`getMainSpecs(product)` - main specs for Product Details page
`getFullSpecs(product)` - full specs for Product Details page

`specsInfo` - shared component that receive `specs` array and `textVariant` for Typography.
specs has look like:
{
  cameraKey:'cameraValue',
  capacityKey:'capacityValue'
}

Note: specsInfo component doesn't have any margins! To add them, wrap specs Info in a container and add margins to container.